### PR TITLE
Add dream refactor

### DIFF
--- a/lib/item.rb
+++ b/lib/item.rb
@@ -1,11 +1,9 @@
 class Item
   attr_reader :name, :price
 
-
   def initialize(attributes)
     @name = attributes[:name]
-    @price = attributes[:price].sub("$", "").to_f
+    @price = attributes[:price].delete("$").to_f
   end
-
 
 end

--- a/lib/market.rb
+++ b/lib/market.rb
@@ -3,14 +3,14 @@ require 'date'
 class Market
   attr_reader :name, :vendors, :date
 
+  def self.get_date
+    Date.today.strftime("%d/%m/%y")
+  end
+
   def initialize(name)
     @name = name
     @vendors = []
-    @date = get_date
-  end
-
-  def get_date
-    Date.today.strftime("%d/%m/%y")
+    @date = Market.get_date
   end
 
   def add_vendor(vendor)
@@ -36,12 +36,16 @@ class Market
   end
 
   def total_inventory
-    vendors.reduce(Hash.new { |market_inventory, item| market_inventory[item] = {quantity: 0, vendors: []} }) do |acc, vendor|
+    market_inventory = Hash.new do |market_inventory, item|
+      market_inventory[item] = {quantity: 0, vendors: []}
+    end
+
+    vendors.reduce(market_inventory) do |market, vendor|
       vendor.inventory.each do |vendor_item, quantity|
-        acc[vendor_item][:quantity] += quantity
-        acc[vendor_item][:vendors] << vendor
+        market[vendor_item][:quantity] += quantity
+        market[vendor_item][:vendors] << vendor
       end
-      acc
+      market
     end
   end
 

--- a/lib/vendor.rb
+++ b/lib/vendor.rb
@@ -15,9 +15,8 @@ class Vendor
   end
 
   def potential_revenue
-    inventory.reduce(0) do |revenue, (item, quantity)|
-      revenue += item.price * quantity
-      revenue
+    @inventory.sum do |item, quantity|
+      item.price * quantity
     end
   end
 

--- a/test/market_test.rb
+++ b/test/market_test.rb
@@ -40,8 +40,9 @@ class MarketTest < MiniTest::Test
   end
 
   def test_it_has_attributes
+    Market.stubs(:get_date).returns("24/02/2020")
+
     market = Market.new("South Pearl Street Farmers Market")
-    market.stubs(:date).returns("24/02/2020")
 
     assert_equal "South Pearl Street Farmers Market", market.name
     assert_equal [], market.vendors
@@ -51,9 +52,7 @@ class MarketTest < MiniTest::Test
   def test_it_can_get_todays_date
     expected_date = Date.today.strftime("%d/%m/%y")
 
-    market = Market.new("South Pearl Street Farmers Market")
-
-    assert_equal expected_date, market.get_date
+    assert_equal expected_date, Market.get_date
   end
 
   def test_it_can_add_vendors


### PR DESCRIPTION
- Use .delete instead of .sub to format price of items

- Use Market.get_date class method instead of instance method .get_date
It allows for proper testing since a market instance initializes with today's date -- there can be a unit test for self.get_date

- Use Market.stubs(:get_date) in testing market.date

- Make Market#total_inventory more readable by assigning the reduce argument to a local variable and breaking the default value block into multiple line syntax.

- Use .sum instead of .reduce for Vendor#potential_revenue